### PR TITLE
Minimal change on *become* syntaxis

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Use the new `become` syntax when designating that a task needs to be run with `s
   template:
     dest: "/etc/sensu/conf.d/client.json"
     src: "client.json.j2"
-  become: true
+  become: yes
 ```
 
 ### Why?


### PR DESCRIPTION
The official documentation for ansible 1.9 says that *become** could be enabled using `yes` and not `true`
I like your guidelines!